### PR TITLE
Fix incorrect indentation when oneway function is used

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -1997,16 +1997,13 @@ void t_py_generator::generate_process_function(t_service* tservice,
       }
     }
 
-    // Shortcut out here for oneway functions
-    if (tfunction->is_oneway()) {
-      return;
+    if (!tfunction->is_oneway()) {
+      f_service_ <<
+        indent() << "oprot.writeMessageBegin(\"" << tfunction->get_name() << "\", TMessageType.REPLY, seqid)" << endl <<
+        indent() << "result.write(oprot)" << endl <<
+        indent() << "oprot.writeMessageEnd()" << endl <<
+        indent() << "oprot.trans.flush()" << endl;
     }
-
-    f_service_ <<
-      indent() << "oprot.writeMessageBegin(\"" << tfunction->get_name() << "\", TMessageType.REPLY, seqid)" << endl <<
-      indent() << "result.write(oprot)" << endl <<
-      indent() << "oprot.writeMessageEnd()" << endl <<
-      indent() << "oprot.trans.flush()" << endl;
 
     // Close function
     indent_down();


### PR DESCRIPTION
The shortcut doesn't work, the next function ends up getting generated inside the previous function, which is bad. 
